### PR TITLE
solve cylinder phantom size in Z direction

### DIFF
--- a/Macro/VObjElem/VObjCylinder.m
+++ b/Macro/VObjElem/VObjCylinder.m
@@ -14,7 +14,7 @@ CenterZ=p.CenterZ;
 [X,Y,Z] = cylinder(Radius,FaceNum); 
 X=X+CenterX;
 Y=Y+CenterY;
-Z=(Z-0.5)*Length/2+CenterZ;
+Z=(Z-0.5)*Length+CenterZ;
 
 fvc = surf2patch(X,Y,Z);
 


### PR DESCRIPTION
cylinder phantom were created with half the set length.
because cylinder() creates Z to be between 0 and 1 it just needs to be multiplied by Length.